### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,4 +65,4 @@ Take a look a the ``bmp180_simpletest.py`` in the examples directory
 
 Documentation
 =============
-API documentation for this library can be found on `Read the Docs <https://circuitpython-qmc5883l.readthedocs.io/>`_.
+API documentation for this library can be found on `Read the Docs <https://circuitpython-bmp180.readthedocs.io/>`_.


### PR DESCRIPTION
The link to the API documentation at the bottom is incorrectly going to docs for the qmc5883l magnetometer. Changing to the correct link for the BMP180 Temperature and Barometric Pressure sensor.